### PR TITLE
Update hugo.yaml

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,6 +1,6 @@
 baseURL: 'https://snidercs.githubpages.io'
 languageCode: en-us
-title: Snider CS
+title: Team 9431 # new name, keeping it simple
 theme: PaperModX
 
 params:
@@ -8,8 +8,8 @@ params:
   defaultTheme: dark
   profileMode:
     enabled: true
-    title: "Snider" # optional default will be site title
-    subtitle: "Computer science..."
+    title: "The Gold Standard" # optional default will be site title
+    subtitle: "Snider's FRC Team 9431"
     imageUrl: "/images/snider-logo-00.png"
     
     # imageTitle: "<title of image as alt>" # optional


### PR DESCRIPTION
"Snider CS" is now "Team 9431", this is the title in the top left of the page. 
"Snider" below the Snider Script image is now "The Gold Standard". 
subtitle is now "Snider's FRC Team 9431"